### PR TITLE
Fix timing issue in delay check

### DIFF
--- a/tktooltip/tooltip.py
+++ b/tktooltip/tooltip.py
@@ -177,7 +177,7 @@ class ToolTip(tk.Toplevel):
         """
         if (
             self.status == ToolTipStatus.INSIDE
-            and time.time() - self.last_moved > self.delay
+            and time.time() - self.last_moved >= self.delay
         ):
             self.status = ToolTipStatus.VISIBLE
 


### PR DESCRIPTION
Changed the condition from `>` to `>=` in the time check `time.time() - self.last_moved > self.delay`. This resolves an issue where the check could fail on Windows due to `time.time()` having a 16ms accuracy, potentially causing `time.time() - self.last_moved` to be 0. This ensures the delay condition works correctly even if `self.delay` is 0.

Related issues: #106, #94 