### PR TITLE
feat: add automatic tooltip repositioning for viewport overflow

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ python_requires = >= 3.7
 install_requires =
     importlib-metadata; python_version < "3.8"
     typing-extensions; python_version < "3.8"
+    screeninfo
 
 [options.packages.find]
 exclude =

--- a/tktooltip/tooltip.py
+++ b/tktooltip/tooltip.py
@@ -87,6 +87,8 @@ class ToolTip(tk.Toplevel):
         self.withdraw()  # Hide initially in case there is a delay
         # Disable ToolTip's title bar
         self.overrideredirect(True)
+        # Mkae ToolTip topmost to display over taskbar
+        self.attributes("-topmost", True)
 
         # StringVar instance for msg string|function
         self.msg_var = tk.StringVar()
@@ -166,13 +168,17 @@ class ToolTip(tk.Toplevel):
                 monitor.x <= event.x_root < monitor.x + monitor.width
                 and monitor.y <= event.y_root < monitor.y + monitor.height
             ):
-                # flip tooltip if it exceedes the monitor's boundaries
-                if w_right > monitor.x + monitor.width:
+                # move tooltip left if it exceedes the monitor's right boundary
+                if w_right >= monitor.x + monitor.width:
                     w_left = (
-                        event.x_root - self.x_offset - self.message_widget.winfo_width()
+                        monitor.x
+                        + monitor.width
+                        - self.message_widget.winfo_width()
+                        - 2
                     )
 
-                if w_bottom > monitor.y + monitor.height:
+                # flip tooltip if it exceedes the monitor's bottom boundary
+                if w_bottom >= monitor.y + monitor.height:
                     w_top = (
                         event.y_root
                         - self.y_offset


### PR DESCRIPTION
Added logic that detects when tooltips would render outside the viewport and automatically flips/updates their position to maintain visibility.

![overflow](https://github.com/user-attachments/assets/729dc28f-d751-41f2-a042-7acb55b6f7cf)

Related: #7 