### PR TITLE
feat: Add animations to the tooltip

### DIFF
--- a/tktooltip/tooltip.py
+++ b/tktooltip/tooltip.py
@@ -4,6 +4,7 @@ Module defining the ToolTip widget
 
 from __future__ import annotations
 
+import sys
 import threading
 import time
 import tkinter as tk
@@ -90,6 +91,9 @@ class ToolTip(tk.Toplevel):
         self.withdraw()  # Hide initially in case there is a delay
         # Disable ToolTip's title bar
         self.overrideredirect(True)
+        # Hide Tooltip's window from the taskbar on Windows
+        if sys.platform == "win32":
+            self.wm_attributes("-toolwindow", True)
 
         # StringVar instance for msg string|function
         self.msg_var = tk.StringVar()
@@ -214,14 +218,13 @@ class ToolTip(tk.Toplevel):
 
             def animation():
                 if not self.is_shown:
+                    self.is_shown = True
                     self.wm_attributes("-alpha", 0)
 
                     for i in range(11):
                         self.wm_attributes("-alpha", 0.1 * i)
                         self.update()
                         time.sleep(0.01)
-
-                    self.is_shown = True
 
             if self.animations:
                 threading.Thread(target=animation, daemon=True).start()

--- a/tktooltip/tooltip.py
+++ b/tktooltip/tooltip.py
@@ -197,6 +197,12 @@ class ToolTip(tk.Toplevel):
             self._update_message()
             self.deiconify()
 
+            if not self.is_shown:
+                x_pos = self.x_offset + self.winfo_pointerx()
+                y_pos = self.y_offset + self.winfo_pointery()
+
+                self.geometry(f"+{x_pos}+{y_pos}")
+
             def animation():
                 if not self.is_shown:
                     self.wm_attributes("-alpha", 0)

--- a/tktooltip/tooltip.py
+++ b/tktooltip/tooltip.py
@@ -46,6 +46,7 @@ class ToolTip(tk.Toplevel):
         msg: str | list[str] | Callable[[], str | list[str]],
         delay: float = 0.0,
         follow: bool = True,
+        animations: bool = True,
         refresh: float = 1.0,
         x_offset: int = +10,
         y_offset: int = +10,
@@ -67,6 +68,9 @@ class ToolTip(tk.Toplevel):
             Delay in seconds before the ToolTip appears, by default 0.0
         follow : `bool`, optional
             ToolTip follows motion, otherwise hides, by default True
+        animations : `bool`, optional
+            ToolTip fades in when showing and fades out when hiding, by default True.
+            This requires a compositing window manager on Linux to have any effect.
         refresh : `float`, optional
             Refresh rate in seconds for strings and functions when mouse is
             stationary and inside the widget, by default 1.0
@@ -93,6 +97,7 @@ class ToolTip(tk.Toplevel):
         self._update_message()
         self.delay = delay
         self.follow = follow
+        self.animations = animations
         self.refresh = refresh
         self.x_offset = x_offset
         self.y_offset = y_offset
@@ -155,7 +160,10 @@ class ToolTip(tk.Toplevel):
 
             self.withdraw()
 
-        threading.Thread(target=animation, daemon=True).start()
+        if self.animations:
+            threading.Thread(target=animation, daemon=True).start()
+        else:
+            self.withdraw()
 
     def _update_tooltip_coords(self, event: tk.Event) -> None:
         """
@@ -213,7 +221,8 @@ class ToolTip(tk.Toplevel):
 
                     self.is_shown = True
 
-            threading.Thread(target=animation, daemon=True).start()
+            if self.animations:
+                threading.Thread(target=animation, daemon=True).start()
 
             # Recursively call _show to update ToolTip with the newest value of msg
             # This is a race condition which only exits when upon a binding change

--- a/tktooltip/tooltip.py
+++ b/tktooltip/tooltip.py
@@ -223,6 +223,8 @@ class ToolTip(tk.Toplevel):
 
             if self.animations:
                 threading.Thread(target=animation, daemon=True).start()
+            else:
+                self.is_shown = True
 
             # Recursively call _show to update ToolTip with the newest value of msg
             # This is a race condition which only exits when upon a binding change

--- a/tktooltip/tooltip.py
+++ b/tktooltip/tooltip.py
@@ -156,6 +156,7 @@ class ToolTip(tk.Toplevel):
 
             for i in range(11):
                 self.wm_attributes("-alpha", 0.1 * (10 - i))
+                self.update()
                 time.sleep(0.01)
 
             self.withdraw()
@@ -217,6 +218,7 @@ class ToolTip(tk.Toplevel):
 
                     for i in range(11):
                         self.wm_attributes("-alpha", 0.1 * i)
+                        self.update()
                         time.sleep(0.01)
 
                     self.is_shown = True


### PR DESCRIPTION
This PR makes the tooltip fade in when it's showing and fade out when it's hiding. The animations are enabled by default, but they can be disabled by setting the `animations` argument to `False`.

Here is a demo:

https://github.com/user-attachments/assets/defa0eac-4d93-4df4-8456-10fba183a7f0